### PR TITLE
chore: update Dependabot configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @panz3r will be requested for review when someone 
+# opens a pull request.
+*             @panz3r
+
+# Owners of the examples
+/examples/*   @panz3r
+
+# Owners of the main library
+/lib          @panz3r

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,15 +10,11 @@ updates:
     directory: "/"
     schedule:
       interval: monthly
-    reviewers:
-      - "panz3r"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: monthly
-    reviewers:
-      - "panz3r"
 
   - package-ecosystem: "npm"
     directories:
@@ -28,5 +24,3 @@ updates:
     schedule:
       interval: weekly
       day: tuesday
-    reviewers:
-      - "panz3r"


### PR DESCRIPTION
This PR applies the changes required to comply with new GitHub policies described here: https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/