### PR TITLE
chore(deps-dev): Bump Vite and React types

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,11 +7,11 @@ settings:
 catalogs:
   default:
     '@types/react':
-      specifier: ^19.1.2
+      specifier: ^19.1.3
       version: 19.1.3
     '@types/react-dom':
-      specifier: ^19.1.2
-      version: 19.1.3
+      specifier: ^19.1.4
+      version: 19.1.4
     '@vitejs/plugin-react':
       specifier: ^4.4.1
       version: 4.4.1
@@ -25,8 +25,8 @@ catalogs:
       specifier: ^5.8.3
       version: 5.8.3
     vite:
-      specifier: ^6.3.3
-      version: 6.3.3
+      specifier: ^6.3.5
+      version: 6.3.5
 
 importers:
 
@@ -62,16 +62,16 @@ importers:
         version: 19.1.3
       '@types/react-dom':
         specifier: 'catalog:'
-        version: 19.1.3(@types/react@19.1.3)
+        version: 19.1.4(@types/react@19.1.3)
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 4.4.1(vite@6.3.3(@types/node@22.15.14)(lightningcss@1.29.3)(terser@5.39.0))
+        version: 4.4.1(vite@6.3.5(@types/node@22.15.14)(lightningcss@1.29.3)(terser@5.39.0))
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
       vite:
         specifier: 'catalog:'
-        version: 6.3.3(@types/node@22.15.14)(lightningcss@1.29.3)(terser@5.39.0)
+        version: 6.3.5(@types/node@22.15.14)(lightningcss@1.29.3)(terser@5.39.0)
 
   examples/refresh-token:
     dependencies:
@@ -96,16 +96,16 @@ importers:
         version: 19.1.3
       '@types/react-dom':
         specifier: 'catalog:'
-        version: 19.1.3(@types/react@19.1.3)
+        version: 19.1.4(@types/react@19.1.3)
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 4.4.1(vite@6.3.3(@types/node@22.15.14)(lightningcss@1.29.3)(terser@5.39.0))
+        version: 4.4.1(vite@6.3.5(@types/node@22.15.14)(lightningcss@1.29.3)(terser@5.39.0))
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
       vite:
         specifier: 'catalog:'
-        version: 6.3.3(@types/node@22.15.14)(lightningcss@1.29.3)(terser@5.39.0)
+        version: 6.3.5(@types/node@22.15.14)(lightningcss@1.29.3)(terser@5.39.0)
 
   examples/reqres:
     dependencies:
@@ -127,16 +127,16 @@ importers:
         version: 19.1.3
       '@types/react-dom':
         specifier: 'catalog:'
-        version: 19.1.3(@types/react@19.1.3)
+        version: 19.1.4(@types/react@19.1.3)
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 4.4.1(vite@6.3.3(@types/node@22.15.14)(lightningcss@1.29.3)(terser@5.39.0))
+        version: 4.4.1(vite@6.3.5(@types/node@22.15.14)(lightningcss@1.29.3)(terser@5.39.0))
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
       vite:
         specifier: 'catalog:'
-        version: 6.3.3(@types/node@22.15.14)(lightningcss@1.29.3)(terser@5.39.0)
+        version: 6.3.5(@types/node@22.15.14)(lightningcss@1.29.3)(terser@5.39.0)
 
   lib:
     dependencies:
@@ -152,7 +152,7 @@ importers:
         version: 6.6.3
       '@testing-library/react':
         specifier: ^16.3.0
-        version: 16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.1.3(@types/react@19.1.3))(@types/react@19.1.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.1.4(@types/react@19.1.3))(@types/react@19.1.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@types/node':
         specifier: ^22.15.3
         version: 22.15.14
@@ -161,13 +161,13 @@ importers:
         version: 19.1.3
       '@types/react-dom':
         specifier: 'catalog:'
-        version: 19.1.3(@types/react@19.1.3)
+        version: 19.1.4(@types/react@19.1.3)
       '@types/use-sync-external-store':
         specifier: ^1.5.0
         version: 1.5.0
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 4.4.1(vite@6.3.3(@types/node@22.15.14)(lightningcss@1.29.3)(terser@5.39.0))
+        version: 4.4.1(vite@6.3.5(@types/node@22.15.14)(lightningcss@1.29.3)(terser@5.39.0))
       jsdom:
         specifier: ^26.1.0
         version: 26.1.0
@@ -179,7 +179,7 @@ importers:
         version: 19.1.0(react@19.1.0)
       vite:
         specifier: 'catalog:'
-        version: 6.3.3(@types/node@22.15.14)(lightningcss@1.29.3)(terser@5.39.0)
+        version: 6.3.5(@types/node@22.15.14)(lightningcss@1.29.3)(terser@5.39.0)
       vitest:
         specifier: ^3.1.2
         version: 3.1.3(@types/node@22.15.14)(jsdom@26.1.0)(lightningcss@1.29.3)(terser@5.39.0)
@@ -626,8 +626,8 @@ packages:
   '@types/node@22.15.14':
     resolution: {integrity: sha512-BL1eyu/XWsFGTtDWOYULQEs4KR0qdtYfCxYAUYRoB7JP7h9ETYLgQTww6kH8Sj2C0pFGgrpM0XKv6/kbIzYJ1g==}
 
-  '@types/react-dom@19.1.3':
-    resolution: {integrity: sha512-rJXC08OG0h3W6wDMFxQrZF00Kq6qQvw0djHRdzl3U5DnIERz0MRce3WVc7IS6JYBwtaP/DwYtRRjVlvivNveKg==}
+  '@types/react-dom@19.1.4':
+    resolution: {integrity: sha512-WxYAszDYgsMV31OVyoG4jbAgJI1Gw0Xq9V19zwhy6+hUUJlJIdZ3r/cbdmTqFv++SktQkZ/X+46yGFxp5XJBEg==}
     peerDependencies:
       '@types/react': ^19.0.0
 
@@ -1392,8 +1392,8 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
-  vite@6.3.3:
-    resolution: {integrity: sha512-5nXH+QsELbFKhsEfWLkHrvgRpTdGJzqOZ+utSdmPTvwHmvU6ITTm3xx+mRusihkcI8GeC7lCDyn3kDtiki9scw==}
+  vite@6.3.5:
+    resolution: {integrity: sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -1864,7 +1864,7 @@ snapshots:
       lodash: 4.17.21
       redent: 3.0.0
 
-  '@testing-library/react@16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.1.3(@types/react@19.1.3))(@types/react@19.1.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@testing-library/react@16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.1.4(@types/react@19.1.3))(@types/react@19.1.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@babel/runtime': 7.27.0
       '@testing-library/dom': 10.4.0
@@ -1872,7 +1872,7 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
     optionalDependencies:
       '@types/react': 19.1.3
-      '@types/react-dom': 19.1.3(@types/react@19.1.3)
+      '@types/react-dom': 19.1.4(@types/react@19.1.3)
 
   '@types/aria-query@5.0.4': {}
 
@@ -1903,7 +1903,7 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@types/react-dom@19.1.3(@types/react@19.1.3)':
+  '@types/react-dom@19.1.4(@types/react@19.1.3)':
     dependencies:
       '@types/react': 19.1.3
 
@@ -1913,14 +1913,14 @@ snapshots:
 
   '@types/use-sync-external-store@1.5.0': {}
 
-  '@vitejs/plugin-react@4.4.1(vite@6.3.3(@types/node@22.15.14)(lightningcss@1.29.3)(terser@5.39.0))':
+  '@vitejs/plugin-react@4.4.1(vite@6.3.5(@types/node@22.15.14)(lightningcss@1.29.3)(terser@5.39.0))':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.10)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.10)
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.3.3(@types/node@22.15.14)(lightningcss@1.29.3)(terser@5.39.0)
+      vite: 6.3.5(@types/node@22.15.14)(lightningcss@1.29.3)(terser@5.39.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -1931,13 +1931,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.1.3(vite@6.3.3(@types/node@22.15.14)(lightningcss@1.29.3)(terser@5.39.0))':
+  '@vitest/mocker@3.1.3(vite@6.3.5(@types/node@22.15.14)(lightningcss@1.29.3)(terser@5.39.0))':
     dependencies:
       '@vitest/spy': 3.1.3
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.3.3(@types/node@22.15.14)(lightningcss@1.29.3)(terser@5.39.0)
+      vite: 6.3.5(@types/node@22.15.14)(lightningcss@1.29.3)(terser@5.39.0)
 
   '@vitest/pretty-format@3.1.3':
     dependencies:
@@ -2630,7 +2630,7 @@ snapshots:
       debug: 4.4.0
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.3.3(@types/node@22.15.14)(lightningcss@1.29.3)(terser@5.39.0)
+      vite: 6.3.5(@types/node@22.15.14)(lightningcss@1.29.3)(terser@5.39.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -2645,7 +2645,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.3.3(@types/node@22.15.14)(lightningcss@1.29.3)(terser@5.39.0):
+  vite@6.3.5(@types/node@22.15.14)(lightningcss@1.29.3)(terser@5.39.0):
     dependencies:
       esbuild: 0.25.3
       fdir: 6.4.4(picomatch@4.0.2)
@@ -2662,7 +2662,7 @@ snapshots:
   vitest@3.1.3(@types/node@22.15.14)(jsdom@26.1.0)(lightningcss@1.29.3)(terser@5.39.0):
     dependencies:
       '@vitest/expect': 3.1.3
-      '@vitest/mocker': 3.1.3(vite@6.3.3(@types/node@22.15.14)(lightningcss@1.29.3)(terser@5.39.0))
+      '@vitest/mocker': 3.1.3(vite@6.3.5(@types/node@22.15.14)(lightningcss@1.29.3)(terser@5.39.0))
       '@vitest/pretty-format': 3.1.3
       '@vitest/runner': 3.1.3
       '@vitest/snapshot': 3.1.3
@@ -2679,7 +2679,7 @@ snapshots:
       tinyglobby: 0.2.13
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.3.3(@types/node@22.15.14)(lightningcss@1.29.3)(terser@5.39.0)
+      vite: 6.3.5(@types/node@22.15.14)(lightningcss@1.29.3)(terser@5.39.0)
       vite-node: 3.1.3(@types/node@22.15.14)(lightningcss@1.29.3)(terser@5.39.0)
       why-is-node-running: 2.3.0
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,8 +3,8 @@ packages:
   - examples/*
 
 catalog:
-  "@types/react": "^19.1.2"
-  "@types/react-dom": "^19.1.2"
+  "@types/react": "^19.1.3"
+  "@types/react-dom": "^19.1.4"
   "@vitejs/plugin-react": "^4.4.1"
   "react": "^19.1.0"
   "react-dom": "^19.1.0"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,4 +9,4 @@ catalog:
   "react": "^19.1.0"
   "react-dom": "^19.1.0"
   "typescript": "^5.8.3"
-  "vite": "^6.3.3"
+  "vite": "^6.3.5"


### PR DESCRIPTION
## Motivation

This PR updates key development dependencies (`vite`, `@types/react`, `@types/react-dom`) to their latest versions. This helps ensure compatibility, leverages potential performance improvements or bug fixes in the dependencies, and keeps the project's tooling up-to-date.

## Description of Changes

* Bumped the common development dependency `@types/react` and `@types/react-dom` (`de189b3`).
* Bumped the common development dependency `vite` (`82136c5`).
* Updated the lock file (`pnpm-lock.yaml` or similar) to reflect the dependency changes (`fe03325`).

## How to Test

1.  **CI Checks:** Verify that all automated tests (Vitest) and build steps pass successfully on this PR.
2.  **Local Verification (Optional):**
    * Run `pnpm install`.
    * Run the development server (`pnpm dev` or equivalent) for the library or examples to ensure Vite starts correctly.
    * Run a build (`pnpm build`) to ensure it completes successfully.

## Checklist

* [ ] My code follows the project's style guidelines (N/A - dependency update).
* [ ] I have updated tests or added new tests to reflect the changes (N/A - dependency update).
* [ ] I have updated the necessary documentation (N/A - dependency update).
* [x] All new and existing tests passed.
* [x] CI checks are passing.
* [x] I have performed a self-review of my own code (Reviewed lock file changes).

## Notes for Reviewers

* This is a routine update for development dependencies.